### PR TITLE
Swap height and width in Matrix.new

### DIFF
--- a/lib/matrix.ex
+++ b/lib/matrix.ex
@@ -33,12 +33,12 @@ defmodule Matrix do
   end
 
   @doc """
-  Creates a new matrix of dimensions `width` x `height`.
+  Creates a new matrix of dimensions `height` x `width`.
 
   Optionally pass in a fourth argument, which will be the default values the matrix will be filled with. (default: `0`)
   """
-  def new(list_of_lists \\ [], width, height, identity \\ 0) when width >= 0 and height >= 0 and (width > 0 or height > 0) do
-    Tensor.new(list_of_lists, [width, height], identity)
+  def new(list_of_lists \\ [], height, width, identity \\ 0) when width >= 0 and height >= 0 and (width > 0 or height > 0) do
+    Tensor.new(list_of_lists, [height, width], identity)
   end
 
   @doc """


### PR DESCRIPTION
Matrices are usually described as having m rows and n columns in an m x n matrix.

The number of rows is the height, and the number of columns is the width, so it should be "height x width".

This does not change any behavior, it just re-labels the arguments to `Matrix.new` to avoid confusion.