### PR TITLE
Correctly handle identity values in Access API

### DIFF
--- a/lib/tensor/tensor.ex
+++ b/lib/tensor/tensor.ex
@@ -212,13 +212,13 @@ defmodule Tensor.Tensor do
     end
     {result, contents} =
       if vector? tensor do
-        {_result, _contents} = Map.get_and_update(tensor.contents, key, fn current_value ->
-          case fun.(current_value) do
-            {^current_value, ^identity} -> :pop
-            other_result -> other_result
-          end
+        current_value = Map.get(tensor.contents, key, identity)
+        case fun.(current_value) do
+          :pop -> {current_value, Map.delete(tensor.contents, key)}
+          {get, ^identity} -> {get, Map.delete(tensor.contents, key)}
+          {get, update} -> {get, Map.put(tensor.contents, key, update)}
+          other -> raise "the given function must return a two-element tuple or :pop, got: #{inspect(other)}"
         end
-        )
       else
         {:ok, ll_tensor} = fetch(tensor, key)
         {result, ll_tensor2} = fun.(ll_tensor)

--- a/test/tensor_test.exs
+++ b/test/tensor_test.exs
@@ -129,4 +129,53 @@ defmodule TensorTest do
     x = Vector.new([1,2,3,4])
     assert FunLand.Reducable.reduce(x, 0, fn x, acc -> acc + x end) == 10
   end
+
+  test "Tensor Access get" do
+    mat = Matrix.new([[1,0],[0,4]],2,2,0)
+    assert mat.contents == %{0 => %{0 => 1}, 1 => %{1 => 4}}
+    assert mat[0][0] == 1
+    assert mat[0][1] == 0
+  end
+
+  test "Tensor Access put_in non-identity" do
+    mat = Matrix.new([[1,0],[0,4]],2,2,0)
+    assert mat.contents == %{0 => %{0 => 1}, 1 => %{1 => 4}}
+    mat2 = put_in(mat[0][0], 6)
+    assert mat2.contents == %{0 => %{0 => 6}, 1 => %{1 => 4}}
+  end
+
+  test "Tensor Access put_in removes identity value" do
+    mat = Matrix.new([[1,0],[0,4]],2,2,0)
+    assert mat.contents == %{0 => %{0 => 1}, 1 => %{1 => 4}}
+    mat2 = put_in(mat[0][0], 0)
+    assert mat2.contents == %{0 => %{}, 1 => %{1 => 4}}
+  end
+
+  test "Tensor Access update_in non-identity" do
+    mat = Matrix.new([[1,0],[0,4]],2,2,0)
+    assert mat.contents == %{0 => %{0 => 1}, 1 => %{1 => 4}}
+    mat2 = update_in(mat[0][0], fn 1 -> 6; _ -> :bad end)
+    assert mat2.contents == %{0 => %{0 => 6}, 1 => %{1 => 4}}
+  end
+
+  test "Tensor Access update_in non-identity to nil" do
+    mat = Matrix.new([[1,0],[0,4]],2,2,0)
+    assert mat.contents == %{0 => %{0 => 1}, 1 => %{1 => 4}}
+    mat2 = update_in(mat[0][0], fn 1 -> nil; _ -> :bad end)
+    assert mat2.contents == %{0 => %{0 => nil}, 1 => %{1 => 4}}
+  end
+
+  test "Tensor Access update_in removes identity value" do
+    mat = Matrix.new([[1,0],[0,4]],2,2,0)
+    assert mat.contents == %{0 => %{0 => 1}, 1 => %{1 => 4}}
+    mat2 = update_in(mat[0][0], fn 1 -> 0; _ -> :bad end)
+    assert mat2.contents == %{0 => %{}, 1 => %{1 => 4}}
+  end
+
+  test "Tensor Access update_in updates identity value" do
+    mat = Matrix.new([[1,0],[0,4]],2,2,0)
+    assert mat.contents == %{0 => %{0 => 1}, 1 => %{1 => 4}}
+    mat2 = update_in(mat[0][1], fn 0 -> 6; _ -> :bad end)
+    assert mat2.contents == %{0 => %{0 => 1, 1 => 6}, 1 => %{1 => 4}}
+  end
 end


### PR DESCRIPTION
The `Access` APIs (particularly `update_in`) don't correctly handle identity values currently, as can be seen in failures of the tests I added in the first commit of this pull request.

The underlying reason for this is `Map.get_and_update/3` passing `nil` to the update function while `Tensor.get_and_update/3` expects to get the identity value.

I fixed the problem in the second commit by replacing the call to `Map.get_and_update/3` with an implementation of the behaviour I believe to be correct. It's basically what `Map.get_and_update/3` already does, but using the tensor's identity instead of `nil` and removing any updated entry that matches the identity.